### PR TITLE
Improve file saving UX

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -80,6 +80,19 @@ class WaifudownloaderWindow(Adw.ApplicationWindow):
         """
         self.dialog = Gtk.FileChooserDialog(title="Save, file", parent=self,
                                             action=Gtk.FileChooserAction.SAVE)
+
+        # Add correct extension to file name
+        file_extension = self.info["images"][0]["extension"][1:]
+        image_filter = Gtk.FileFilter()
+        image_filter.set_name(f"{file_extension.upper()} files")
+        image_filter.add_pattern(f"*.{file_extension}")
+        self.dialog.add_filter(image_filter)
+
+        # Suggest a sensible default filename
+        # using this format ensures the image source can easily be found from its name
+        image_id = self.info["images"][0]["image_id"]
+        self.dialog.set_current_name(f"waifu.im_{image_id}.{file_extension}")
+
         # Buttons
         self.dialog.add_button('Cancel', Gtk.ResponseType.CANCEL)
         self.dialog.add_button('Save', Gtk.ResponseType.OK)


### PR DESCRIPTION
It was very annoying that I had to type the full name of the file when saving it, and I had no idea what the extension was, I just assumed they were PNG and saved as that.

This PR makes it so the correct file extension is suggested along with a suggested name that contains both the domain and image ID, making it easier to find the original source if needed (and because coming up with names is hard sometimes).

After this gets merged I'll create a PR with the same changes for [CatgirlDownloader](https://github.com/NyarchLinux/CatgirlDownloader) as well.

Here is a screenshot from before:
![image](https://github.com/user-attachments/assets/24c703bd-8e3c-4da7-88d2-1a33f11b625f)

And after:
![image](https://github.com/user-attachments/assets/c5528d91-dc27-4f01-ae93-c8e025e09418)
